### PR TITLE
Use defaults in map.jinja

### DIFF
--- a/python/map.jinja
+++ b/python/map.jinja
@@ -1,19 +1,19 @@
 {% set python2 = salt['grains.filter_by']({
-    'Debian': {
+    'default': {
         'pkg': 'python',
-        'dev_pkg': 'python-dev',
-        'mako_pkg': 'python-mako',
         'pip_pkg': 'python-pip',
+        'mako_pkg': 'python-mako',
+        'version': '',
+    },
+    'Debian': {
+        'dev_pkg': 'python-dev',
         'm2c_pkg': 'python-m2crypto',
     },
     'RedHat': {
-        'pkg': 'python',
         'dev_pkg': 'python-devel',
-        'mako_pkg': 'python-mako',
-        'pip_pkg': 'python-pip',
         'm2c_pkg': 'python-m2ext',
     },
-}, merge=salt['pillar.get']('python2:lookup')) %}
+}, merge=salt['pillar.get']('python2:lookup'), base='default') %}
 
 {% set python3 = salt['grains.filter_by']({
     'Debian': {

--- a/python/map.jinja
+++ b/python/map.jinja
@@ -16,16 +16,15 @@
 }, merge=salt['pillar.get']('python2:lookup'), base='default') %}
 
 {% set python3 = salt['grains.filter_by']({
-    'Debian': {
+    'default': {
         'pkg': 'python3',
-        'dev_pkg': 'python3-dev',
-        'mako_pkg': 'python3-mako',
         'pip_pkg': 'python3-pip',
+        'mako_pkg': 'python3-mako',
+    },
+    'Debian': {
+        'dev_pkg': 'python3-dev',
     },
     'RedHat': {
-        'pkg': 'python3',
         'dev_pkg': 'python3-devel',
-        'mako_pkg': 'python3-mako',
-        'pip_pkg': 'python3-pip',
     },
-}, merge=salt['pillar.get']('python3:lookup')) %}
+}, merge=salt['pillar.get']('python3:lookup'), base='default') %}


### PR DESCRIPTION
Dear maintainers of python2-formula

First of all thanks for providing the formula, it has been very useful for us as we are supporting mac/linux/windows. 

In this PR I'm adding a default configuration to make the code a bit more DRY and to allow usage on OSX without updating the map.jinja. 

We also worked on adding support for windows. The master branch of my fork contains a working version. It however introduces a dependency on win-repo AND requires the formula to setup the PATH variable on windows so python can be found. On top of that it needs to create a symlink into a system directory so the root user on windows picks up the python version when installing using salt. 

If there is interest in also including the windows related part into python2-formula, I'm happy to open a PR for that as well. 


